### PR TITLE
Include current year in header

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ var banner = [ "/**",
 	" * Author: <%= pkg.author %>",
 	" * Version: v<%= pkg.version %>",
 	" * Url: <%= pkg.homepage %>",
-	" * License(s): <% pkg.licenses.forEach(function( license, idx ){ %><%= license.type %> Copyright (c) 2014 LeanKit<% if(idx !== pkg.licenses.length-1) { %>, <% } %><% }); %>",
+	" * License(s): <% pkg.licenses.forEach(function( license, idx ){ %><%= license.type %> Copyright (c) <%= ( new Date() ).getFullYear() %> LeanKit<% if(idx !== pkg.licenses.length-1) { %>, <% } %><% }); %>",
 	" */",
 "" ].join( "\n" );
 


### PR DESCRIPTION
The header has 2014 for copyright. Update gulp to include the current year, so future releases have the correct year.