### PR TITLE
Catch unfixable jscs errors in gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require( "gulp" );
+var gutil = require( "gulp-util" );
 var sourcemaps = require( "gulp-sourcemaps" );
 var rename = require( "gulp-rename" );
 var header = require( "gulp-header" );
@@ -78,6 +79,10 @@ gulp.task( "format", [ "jshint" ], function() {
 			configPath: ".jscsrc",
 			fix: true
 		} ) )
+		.on( "error", function( error ) {
+			gutil.log( gutil.colors.red( error.message ) );
+			this.end();
+		} )
 		.pipe( gulpChanged( ".", { hasChanged: gulpChanged.compareSha1Digest } ) )
 		.pipe( gulp.dest( "." ) );
 } );

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gulp-sourcemaps": "^1.5.0",
     "gulp-spawn-mocha": "^2.0.1",
     "gulp-uglify": "^1.1.0",
+    "gulp-util": "~3.0.5",
     "istanbul": "^0.3.10",
     "jshint-stylish": "^1.0.1",
     "mocha": "^2.2.0",


### PR DESCRIPTION
Properly handle errors in jscs build task when there are issues that can't be fixed